### PR TITLE
Docker env cleaning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   salt-api:
     build:
       context: "salt_master_docker"
-      dockerfile: Dockerfile # Salt-api develop, comment of need salt-api stable
-      # dockerfile: Dockerfile_stable # Uncomment for salt-api stable
+      dockerfile: Dockerfile_stable # Salt-api stable, comment for salt-api develop
+      # dockerfile: Dockerfile # Salt-api develop, uncomment for salt-api develop
     ports:
       - 8000:8000
       - 5417:5417

--- a/docs/saltpad-docker.md
+++ b/docs/saltpad-docker.md
@@ -5,14 +5,15 @@ Saltpad includes both a Dockerfile for creating a saltpad docker image and a doc
 
 # Saltpad with docker-compose
 
+You can setup automatically a salt-api with salt-master and salt-minion for testing saltpad safely without impacting your production.
 
-You can setup automatically a salt-api with salt-master and salt-minion for testing saltpad safely without impacting your production. It is also required for the moment as saltpad requires develop version of salt-api.
-
-The image generated for salt-api will contains the latest develop version of salt, a salt-master, a salt-minion and two salt-api running in HTTP.
+The image generated for salt-api will contains the latest stable version of salt, a salt-master, a salt-minion and two salt-api running in HTTP. You can this way test with your configured salt-api implementation or the other one very easily.
 
 The salt-api running rest_cherrypy will run on port 8000 and should be available on your host with the same port, so you can put ```localhost:8000``` for ```API_URL``` in your file ```settings.json```.
 
 The salt-api running rest_tornado will run on port 5417 and should be available on your host with the same port, so you can put ```localhost:5417``` for ```API_URL``` in your file ```settings.json```.
+
+> You need to put only one `API_URL` in your `settings.json` file.
 
 Depending on your setup, these ports may need to be mapped manually (like for example with docker-machine and virtualbox) or available on a different host (like with dlite). You can try to access via your browser on the salt-api URLs before trying to run saltpad, if they are not accessible via your browser, saltpad will not works.
 
@@ -20,11 +21,42 @@ Depending on your setup, these ports may need to be mapped manually (like for ex
 
 It's very similar as for docker alone.
 
-**Don't forget to create the ```settings.json``` file first**
+**Don't forget to create the ```settings.json``` file first in the root directory**
+
+The `docker-compose.yml` file is in the root directory of the repository, you can build the different docker images with this command launched also from the root directory:
 
 ```
 docker-compose build
 ```
+
+
+### Custom salt version
+
+You can choose a different version of salt to play with. Just edit the file ```salt_master_docker/Dockerfile_stable``` and change the `SALT_VERSION` variable. You'll need to rerun the `docker-compose build` command after modifying this variable.
+
+#### Old salt version
+
+If you want to try saltpad with a salt version older than 2016.3.0, your `settings.json` will be a little different.
+
+You'll need first to build saltpad locally with this command launch from the root directory:
+
+`npm run build`
+
+In old versions, only the rest_cherrypy deployment works against the stable version, so you need to put ```localhost:8000``` for ```API_URL``` and ```/saltpad/``` for ```PATH_PREFIX``` in your file ```settings.json```.
+
+You should then be able to access saltpad on this url: `http://localhost:8000/saltpad`.
+
+Please refer to the main (documentation)[https://github.com/Lothiraldan/saltpad/blob/master/docs/installation/salt-api-cherrypy-embedded.md] for more informations on the subject.
+
+## Run
+
+Now that you have built the docker images, you can launch them, it will start two docker container, one with a salt-master, a salt-minion and the two implementations of salt-api and one with saltpad itself. This command need to be launched from the root directory:
+
+```
+docker-compose run
+```
+
+The cherry-py salt-api should be accessible at: `http://localhost:8000`, the tornado salt-api should be accessible at: `http://localhost:5417` and saltpad should be accessible at: `http://localhost:3333`.
 
 ### Execute salt commands
 
@@ -34,26 +66,17 @@ If you need to execute salt commands on the salt-master, you can execute this co
 docker exec -t -i $(docker ps | grep "salt-api" | cut -d " " -f 1) bash
 ```
 
-## Run
+# Saltpad with docker-compose and salt-api develop
 
-```
-docker-compose run
-```
+The docker-compose environment introduced earlier starts a stable version of salt-api.
 
-# Saltpad with docker-compose and salt-api stable
+There is an alternative salt-master Docker image that use salt-api develop instead of stable version.
 
-There is an alternative Docker image that use salt-api stable instead of develop version.
-
-The configuration is the same than the one on develop version, but it can help you test saltpad against a stable version of salt-api. For now, only the rest_cherrypy deployment works against the stable version, so you need to put ```localhost:8000``` for ```API_URL``` and ```/saltpad/``` for ```PATH_PREFIX``` in your file ```settings.json```. You will also need to build saltpad first, using the command ```npm run build```.
-
-Please refer to the main README for more informations on the subject.
-
-Uncomment the right ```dockerfile``` line in docker-compose.yml (the one actually commented), build the docker images with ```docker-compose build```, launch them with ```docker-compose up``` then access ```http://localhost:8000/saltpad``` to have access to saltpad.
+Uncomment the right ```dockerfile``` line in docker-compose.yml (the one actually commented), build the docker images with ```docker-compose build```, launch them with ```docker-compose up``` then access ```http://localhost:3333/``` to have access to saltpad.
 
 # Saltpad docker image
 
-The dockerfile will build a docker container to run saltpad in. It will use the file ```settings.json``` to configure
-the container.
+The dockerfile located in the root directory will build a docker container to run saltpad in. It will use the file `settings.json` co-located in the root directory to configure the container.
 
 **Note: This will need more work to run in production, for now - only use for development.**
 
@@ -63,7 +86,7 @@ the container.
 
 You can build a saltpad image which will package the current version of the code located on your copy of this repository.
 
-**Don't forget to create the ```settings.json``` file first**
+**Don't forget to create the ```settings.json``` file first with informations for either a local salt-api you configured earlier or a staging salt-api**
 
 ```
 docker build -t name/saltpad:latest .

--- a/salt_master_docker/Dockerfile_stable
+++ b/salt_master_docker/Dockerfile_stable
@@ -5,9 +5,11 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get upgrade -y -o DPkg::Options::=--force-confold
 
+ENV SALT_VERSION=2016.3.0
+
 # Install salt-master deps
 RUN apt-get install -y python-apt procps pciutils python-pip python-dev
-RUN pip install https://pypi.python.org/packages/source/s/salt/salt-2015.8.8.tar.gz#md5=99ce814992f07d661440dfcecbba6262 cherrypy tornado
+RUN pip install salt==$SALT_VERSION cherrypy tornado
 
 # Volume for saltpad deployment with rest_cherrypy
 


### PR DESCRIPTION
Add more details in the docker readme.
Move to stable salt-api by default.
Make the salt-api version configurable in the Dockerfile

@TheBigBear could you give it a look and give me your feedback?