### PR TITLE
Support API prefix

### DIFF
--- a/app/services/base_service.js
+++ b/app/services/base_service.js
@@ -8,17 +8,18 @@ axios.defaults.headers.common['Accept'] = 'application/json';
 export default class BaseService {
     baseUrl() {
         let settings = store.get('settings');
-
         return URI("")
             .host(settings.API_URL)
             .scheme(`${settings.SECURE_HTTP ? 'https' : 'http'}`);
     }
 
     get(segment, ...params) {
-        return axios.get(this.baseUrl().segment(segment), ...params);
+        let settings = store.get('settings');
+        return axios.get(this.baseUrl().segment([settings.API_PATH].concat(segment)), ...params);
     }
 
     post(segment, data, ...params) {
-        return axios.post(this.baseUrl().segment(segment), data, ...params);
+        let settings = store.get('settings');
+        return axios.post(this.baseUrl().segment([settings.API_PATH].concat(segment)), data, ...params);
     }
 }

--- a/app/services/real-time.js
+++ b/app/services/real-time.js
@@ -36,15 +36,14 @@ function real_time_factory() {
         var url = URI("")
             .host(settings.API_URL)
             .scheme(`${settings.SECURE_HTTP ? 'https' : 'http'}`)
-            .segment(['events'])
+            .segment([settings.API_PATH, 'events'])
             .search({'token': token});
         var source = new EventSource(url);
     } else {
         var url = URI("")
             .host(settings.API_URL)
             .scheme(`${settings.SECURE_HTTP ? 'wss' : 'ws'}`)
-            .segment(['all_events', token]);
-
+            .segment([settings.API_PATH, 'all_events', token]);
         var source = new WebSocket(url);
     }
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "express": "",
     "form-urlencoded": "",
     "html-webpack-plugin": "",
-    "extract-text-webpack-plugin": ">=1.0.1",
+    "extract-text-webpack-plugin": ">=2.0.0-rc.3",
     "cosmos-js": "^0.7.0",
     "yargs": "^3.30.0"
   },

--- a/settings.json.sample
+++ b/settings.json.sample
@@ -1,5 +1,6 @@
 {
     "API_URL": "localhost:5417", # The API URL
+    "API_PATH": "/", # The API path
     "SECURE_HTTP": false, # Is the API protected by HTTPS?
     "templates": { # Templates sample
         "basic": { # Template name
@@ -22,5 +23,5 @@
     },
     "EAUTH": "pam", # The configured external_auth system
     "FLAVOUR": "rest_cherrypy", # The netapi implementation configured on salt-master
-    "PATH_PREFIX": "/", # The prefix of saltpad url
+    "PATH_PREFIX": "/" # The prefix of saltpad url
 }

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -15,7 +15,7 @@ module.exports = {
     filename: "/static/[name].js"
   },
   plugins: [
-    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.optimize.OccurrenceOrderPlugin(),
     // new webpack.DefinePlugin({
     //   'process.env': {
     //     'NODE_ENV': JSON.stringify('production')
@@ -33,27 +33,35 @@ module.exports = {
     new ExtractTextPlugin("/static/styles.css"),
   ],
   resolve: {
-    extensions: ['', '.js', '.jsx'],
+    extensions: ['*', '.js', '.jsx'],
     // Tell webpack to look for required files in bower and node
-    modulesDirectories: ['bower_components', 'node_modules']
+    modules: ['bower_components', 'node_modules']
   },
   module: {
     loaders: [
       {
         test: /\.jsx?$/,
-        loaders: ['babel?optional[]=runtime&stage=0'],
+        loaders: ['babel-loader?optional[]=runtime&stage=0'],
         include: path.join(__dirname, 'app')
       },
+      { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: "file-loader?name=/static/[name]-[hash].[ext]" },
+      { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: "file-loader?name=/static/[name]-[hash].[ext]" },
+      { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: "file-loader?name=/static/[name]-[hash].[ext]" },
+      { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file-loader?name=/static/[name]-[hash].[ext]" },
+      { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "file-loader?name=/static/[name]-[hash].[ext]" },
+      { test: /\.jpg$/, loader: "file-loader?name=[name]-[hash].[ext]" },
+      { test: /\.png$/, loader: "file-loader?name=[name]-[hash].[ext]" },
       {
-        test: /\.css$/, loader: ExtractTextPlugin.extract("style-loader", "css-loader")
-      },
-      { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: "file?name=/static/[name]-[hash].[ext]" },
-      { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: "file?name=/static/[name]-[hash].[ext]" },
-      { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: "file?name=/static/[name]-[hash].[ext]" },
-      { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file?name=/static/[name]-[hash].[ext]" },
-      { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "file?name=/static/[name]-[hash].[ext]" },
-      { test: /\.jpg$/, loader: "file?name=[name]-[hash].[ext]" },
-      { test: /\.png$/, loader: "file?name=[name]-[hash].[ext]" },
+        rules: [
+          {
+            test: /\.css$/,
+            use: ExtractTextPlugin.extract({
+              fallback: "style-loader",
+              use: "css-loader"
+            })
+          }
+        ]
+      }
     ]
   }
 };


### PR DESCRIPTION
In the SaltPad doc, it is recommended to put salt-api behind a reverse proxy (Apache HTTPD or Nginx) with the URL /api.

SaltPad doesn't support it. This patch add an API_PREFIX to specify the path of the API.